### PR TITLE
First guess for an ACL extension

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -8,3 +8,5 @@ $conf['title_key'] = 'entry title';
 $conf['debug'] = 0;
 
 $conf['enable_entry'] = 1;
+
+$conf['use_acl'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -8,3 +8,5 @@ $meta['title_key'] = array('string');
 $meta['debug'] = array('onoff');
 
 $meta['enable_entry'] = array('onoff');
+
+$meta['use_acl'] = array('onoff');

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -9,6 +9,8 @@ $lang['error_triples_add'] = 'Strata storage: Failed to add triples: %s';
 $lang['error_triples_query'] = 'Strata storage: Failed to execute query: %s';
 $lang['error_triples_node'] = 'Strata storage: Unknown abstract query tree node type \'%s\'';
 
+$lang['error_graphs_fetch'] = 'Strata storage: Failed to fetch unique graphs: %s';
+
 $lang['debug_sql'] = 'Debug SQL: <code>%s</code>';
 $lang['debug_literals'] = 'Debug Literals: <pre>%s</pre>';
 

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -8,3 +8,4 @@ $lang['title_key'] = 'The name of the \'entry title\' relation';
 $lang['debug'] = 'Enable debug information? (Warning: enabling debug information may expose confidential information)';
 
 $lang['enable_entry'] = 'Is the data entry syntax enabled?';
+$lang['use_acl'] = 'Should the results be filtered according to the ACL rules?';

--- a/sql/setup-mysql.sql
+++ b/sql/setup-mysql.sql
@@ -11,3 +11,5 @@ CREATE INDEX idx_spo ON data(subject(32), predicate(32), object(32)); -- Prefix 
 -- index for predicate-primary retrieval (i.e. property fetch)
 CREATE INDEX idx_pso ON data(predicate(32), subject(32), object(32)); -- Prefix length is arbitrary
 
+-- index for ACL rule checks
+CREATE INDEX idx_g ON data(graph);

--- a/sql/setup-pgsql.sql
+++ b/sql/setup-pgsql.sql
@@ -11,3 +11,5 @@ CREATE INDEX idx_spo ON data(lower(subject), lower(predicate), lower(object));
 -- index for predicate-primary retrieval (i.e. property fetch)
 CREATE INDEX idx_pso ON data(lower(predicate), lower(subject), lower(object));
 
+-- index for ACL rule checks
+CREATE INDEX idx_g ON data(graph);

--- a/sql/setup-sqlite.sql
+++ b/sql/setup-sqlite.sql
@@ -10,3 +10,6 @@ CREATE INDEX idx_spo ON data(subject, predicate, object);
 
 -- index for predicate-primary retrieval (i.e. property fetch)
 CREATE INDEX idx_pso ON data(predicate, subject, object);
+
+-- index for ACL rule checks
+CREATE INDEX idx_g ON data(graph);

--- a/syntax/select.php
+++ b/syntax/select.php
@@ -16,6 +16,7 @@ class syntax_plugin_strata_select extends DokuWiki_Syntax_Plugin {
         $this->helper =& plugin_load('helper', 'strata_syntax');
         $this->util =& plugin_load('helper', 'strata_util');
         $this->triples =& plugin_load('helper', 'strata_triples');
+        $this->triples->init_blocked_graphs();
     }
 
     function getType() {


### PR DESCRIPTION
This is my first attempt for ACL rules in strata ...

The basic idea is, that once in the page build process an index of blocked pages is generated

`helper_plugin_strata_triples::$blocked_graphs_sql`

This index is represented as a SQL filter

`AND graph NOT IN ('abc:def', 'abc:xyz')`

which will be injected into the SQL code in `_trans_tp()`. This should prevent that any private information is gathered by the plugin. For performance reasons an additional SQL index is introduced.
