### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -21,7 +21,7 @@ class action_plugin_strata extends DokuWiki_Action_Plugin {
      *
      * @param controller object the controller to register with
      */
-    public function register(Doku_Event_Handler &$controller) {
+    public function register(Doku_Event_Handler $controller) {
         $controller->register_hook('IO_WIKIPAGE_WRITE', 'BEFORE', $this, '_io_page_write');
         $controller->register_hook('PARSER_METADATA_RENDER', 'BEFORE', $this, '_parser_metadata_render_before');
         $controller->register_hook('STRATA_PREVIEW_METADATA_RENDER', 'BEFORE', $this, '_parser_metadata_render_before');

--- a/syntax/entry.php
+++ b/syntax/entry.php
@@ -38,7 +38,7 @@ class syntax_plugin_strata_entry extends DokuWiki_Syntax_Plugin {
         }
     }
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         $result = array(
             'entry'=>'',
             'data'=> array(
@@ -239,7 +239,7 @@ class syntax_plugin_strata_entry extends DokuWiki_Syntax_Plugin {
         return array($currentPosition, $previousPosition, $nextPosition);
     }
 
-    function render($mode, &$R, $data) {
+    function render($mode, Doku_Renderer $R, $data) {
         global $ID;
 
         if($data == array()) {

--- a/syntax/info.php
+++ b/syntax/info.php
@@ -38,7 +38,7 @@ class syntax_plugin_strata_info extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('~~INFO:strataaggregates~~',$mode,'plugin_strata_info');
     }
 
-    public function handle($match, $state, $pos, &$handler){
+    public function handle($match, $state, $pos, Doku_Handler $handler){
         $data = array();
         preg_match('/~~INFO:strata(type|aggregate)s~~/',$match, $captures);
         list(,$kind) = $captures;
@@ -72,7 +72,7 @@ class syntax_plugin_strata_info extends DokuWiki_Syntax_Plugin {
         return strcmp($a['name'], $b['name']);
     }
 
-    public function render($mode, &$R, $data) {
+    public function render($mode, Doku_Renderer $R, $data) {
         if($mode == 'xhtml') {
             list($kind, $items) = $data;
 

--- a/syntax/list.php
+++ b/syntax/list.php
@@ -20,7 +20,7 @@ class syntax_plugin_strata_list extends syntax_plugin_strata_select {
         return preg_replace('/(^<list)|( *>$)/','',$header);
     }
 
-    function render($mode, &$R, $data) {
+    function render($mode, Doku_Renderer $R, $data) {
         if($data == array() || isset($data['error'])) {
             if($mode == 'xhtml') {
                 $R->listu_open();

--- a/syntax/nodata.php
+++ b/syntax/nodata.php
@@ -34,11 +34,11 @@ class syntax_plugin_strata_nodata extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('~~NODATA~~',$mode,'plugin_strata_nodata');
     }
 
-    public function handle($match, $state, $pos, &$handler){
+    public function handle($match, $state, $pos, Doku_Handler $handler){
         return array();
     }
 
-    public function render($mode, &$R, $data) {
+    public function render($mode, Doku_Renderer $R, $data) {
         if($mode == 'metadata') {
             $R->info['data'] = false;
             return true;

--- a/syntax/select.php
+++ b/syntax/select.php
@@ -63,7 +63,7 @@ class syntax_plugin_strata_select extends DokuWiki_Syntax_Plugin {
         return array('choices' => array('none' => array('none', 'no', 'n'), 'generic' => array('generic', 'g')), 'default' => ($hasUIBlock ? 'generic' : 'none'));
     }
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         try {
             $result = array();
             $typemap = array();
@@ -275,7 +275,7 @@ class syntax_plugin_strata_select extends DokuWiki_Syntax_Plugin {
      * @param R the renderer
      * @param data the custom data from the handle phase
      */
-    function render($mode, &$R, $data) {
+    function render($mode, Doku_Renderer $R, $data) {
         return false;
     }
 

--- a/syntax/table.php
+++ b/syntax/table.php
@@ -24,7 +24,7 @@ class syntax_plugin_strata_table extends syntax_plugin_strata_select {
         return preg_replace('/(^<table)|( *>$)/','',$header);
     }
 
-    function render($mode, &$R, $data) {
+    function render($mode, Doku_Renderer $R, $data) {
         if($data == array() || isset($data['error'])) {
             if($mode == 'xhtml') {
                 $R->table_open();


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.